### PR TITLE
テストカバレッジの向上

### DIFF
--- a/__tests__/components/theme-toggle.test.tsx
+++ b/__tests__/components/theme-toggle.test.tsx
@@ -33,9 +33,9 @@ describe('ThemeToggle', () => {
     render(<ThemeToggle />);
     
     // Moonアイコンが表示されていることを確認
-    // Note: SVGアイコンは直接テストが難しいため、aria-labelなどがあると良い
     const button = screen.getByRole('button', { name: /テーマを切り替える/i });
     expect(button).toBeInTheDocument();
+    expect(button.innerHTML).toContain('lucide-moon');
   });
 
   it('shows sun icon when theme is dark', () => {
@@ -50,6 +50,23 @@ describe('ThemeToggle', () => {
     // Sunアイコンが表示されていることを確認
     const button = screen.getByRole('button', { name: /テーマを切り替える/i });
     expect(button).toBeInTheDocument();
+    expect(button.innerHTML).toContain('lucide-sun');
+  });
+  
+  it('handles system theme correctly', () => {
+    // モックの戻り値を設定（systemテーマ）
+    (useTheme as jest.Mock).mockReturnValue({
+      theme: 'system',
+      setTheme: jest.fn(),
+    });
+
+    render(<ThemeToggle />);
+    
+    // システムテーマの場合もボタンが表示されることを確認
+    const button = screen.getByRole('button', { name: /テーマを切り替える/i });
+    expect(button).toBeInTheDocument();
+    // システムテーマの場合はデフォルトでMoonアイコンを表示
+    expect(button.innerHTML).toContain('lucide-moon');
   });
 
   it('toggles theme when clicked', () => {

--- a/__tests__/components/theme-toggle.test.tsx
+++ b/__tests__/components/theme-toggle.test.tsx
@@ -35,7 +35,7 @@ describe('ThemeToggle', () => {
     // Moonアイコンが表示されていることを確認
     const button = screen.getByRole('button', { name: /テーマを切り替える/i });
     expect(button).toBeInTheDocument();
-    expect(button.innerHTML).toContain('lucide-moon');
+    expect(screen.getByTestId('theme-icon-moon')).toBeInTheDocument();
   });
 
   it('shows sun icon when theme is dark', () => {
@@ -50,7 +50,7 @@ describe('ThemeToggle', () => {
     // Sunアイコンが表示されていることを確認
     const button = screen.getByRole('button', { name: /テーマを切り替える/i });
     expect(button).toBeInTheDocument();
-    expect(button.innerHTML).toContain('lucide-sun');
+    expect(screen.getByTestId('theme-icon-sun')).toBeInTheDocument();
   });
   
   it('handles system theme correctly', () => {
@@ -66,7 +66,7 @@ describe('ThemeToggle', () => {
     const button = screen.getByRole('button', { name: /テーマを切り替える/i });
     expect(button).toBeInTheDocument();
     // システムテーマの場合はデフォルトでMoonアイコンを表示
-    expect(button.innerHTML).toContain('lucide-moon');
+    expect(screen.getByTestId('theme-icon-moon')).toBeInTheDocument();
   });
 
   it('toggles theme when clicked', () => {

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -25,7 +25,10 @@ export default function ThemeToggle() {
       aria-label="テーマを切り替える"
       className="text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-50 dark:hover:bg-gray-800"
     >
-      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+      {theme === "dark" ? 
+        <Sun className="h-5 w-5" data-testid="theme-icon-sun" /> : 
+        <Moon className="h-5 w-5" data-testid="theme-icon-moon" />
+      }
     </Button>
   )
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,48 @@ const customJestConfig = {
   },
   // テスト環境を指定
   testEnvironment: 'jest-environment-jsdom',
+  // カバレッジレポートの設定
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  collectCoverageFrom: [
+    'components/**/*.{ts,tsx}',
+    'lib/**/*.{ts,tsx}',
+    'app/**/*.{ts,tsx}',
+    '!**/node_modules/**',
+    '!**/.next/**',
+    '!**/coverage/**',
+    '!jest.config.js',
+    '!next.config.mjs',
+    '!**/*.d.ts',
+  ],
+  coverageThreshold: {
+    // 主要コンポーネントとライブラリのみ高いカバレッジを要求
+    "./components/*.tsx": {
+      branches: 80,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    },
+    "./lib/*.{ts,tsx}": {
+      branches: 80,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    },
+    "./app/page.tsx": {
+      branches: 80,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    },
+    // 全体的なカバレッジは低めに設定
+    global: {
+      branches: 5,
+      functions: 20,
+      lines: 10,
+      statements: 10,
+    },
+  },
 };
 
 // createJestConfigを定義することによって、本ファイルで定義された設定がNext.jsの設定に反映される


### PR DESCRIPTION
## 変更内容

- カバレッジ閾値を調整
  - 主要コンポーネントとライブラリのみ高いカバレッジを要求
  - 全体的なカバレッジは低めに設定
- テストの修正
  - theme-toggle.testのアイコン検証方法を修正

## 目的

テストカバレッジを向上させ、主要コンポーネントの品質を確保します。